### PR TITLE
Adding business and authorized businesses attibutes

### DIFF
--- a/src/models/site.model.ts
+++ b/src/models/site.model.ts
@@ -63,4 +63,12 @@ export class ThreeSiteModel extends Model {
   @io.all
   public axis?: Array<number>;
 
+  @type.string
+  @io.all
+  @query.filterable()
+  public business: string;
+  
+  @type.array({type: 'string'})
+  @io.all
+  public authorizedBusinesses?: Array<string>;
 }


### PR DESCRIPTION
We added business  and authorizedBusinesses in order to specify the business context of a site.
business being the context.
authorizedBusinesses being a map of businesses contexts allowed to interract with the current business

Feel free to comment
Boris